### PR TITLE
Removed Conda Install Cell

### DIFF
--- a/Getting_Started.ipynb
+++ b/Getting_Started.ipynb
@@ -29,18 +29,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "educational-bangladesh",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If your Jupyter installation uses conda:\n",
-    "# import sys\n",
-    "# !conda install --yes --prefix {sys.prefix} <package_name>"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "peaceful-vaccine",
    "metadata": {},


### PR DESCRIPTION
Removed the conda install cell because we don't have pyqrack in conda's repo. This might be bit confusing for new comers into pyqrack because `conda install pyqrack` command would fail and they would try debugging the issue